### PR TITLE
chore: refactor BTCPay invoice metadata

### DIFF
--- a/app/src/app/business/BusinessDetails/BusinessDetails.tsx
+++ b/app/src/app/business/BusinessDetails/BusinessDetails.tsx
@@ -11,21 +11,21 @@ import { BusinessContent } from "./BusinessContent/BusinessContent";
 import { BusinessHeader } from "./BusinessHeader/BusinessHeader";
 import { InvestNowWidget } from "./InvestNowWidget/InvestNowWidget";
 
-export const BusinessDetails: React.FC<BusinessDetailsProps> = ({ campaign: { content } }) => (
+export const BusinessDetails: React.FC<BusinessDetailsProps> = ({ campaign }) => (
   <div className={clsx(styles["business-details"])}>
-    <InvestNowWidget content={content} />
+    <InvestNowWidget campaign={campaign} />
     <Grid.Container>
       <Grid.Row>
         <Grid.Col lg={8}>
           <Card className={styles["business-details__box"]} shadow>
-            <BusinessHeader content={content} />
+            <BusinessHeader content={campaign.content} />
             <Tab defaultPaneId="business-content-tab">
               <Tab.Navigation>
                 <Tab.Item paneId="business-content-tab">Oportunidad de Inversión</Tab.Item>
                 <Tab.Item paneId="business-financials-tab">Finanzas y Datos</Tab.Item>
               </Tab.Navigation>
               <Tab.Pane id="business-content-tab">
-                <BusinessContent content={content} />
+                <BusinessContent content={campaign.content} />
               </Tab.Pane>
               <Tab.Pane id="business-financials-tab">
                 <Typography.Text>Finanzas y Datos</Typography.Text>

--- a/app/src/app/business/BusinessDetails/InvestNowWidget/InvestNowWidget.tsx
+++ b/app/src/app/business/BusinessDetails/InvestNowWidget/InvestNowWidget.tsx
@@ -16,7 +16,7 @@ import { useCheckoutContext } from "hooks/useCheckoutContext/useCheckoutContext"
 import { InvestNowWidgetProps } from "./InvestNowWidget.types";
 import styles from "./InvestNowWidget.module.scss";
 
-export const InvestNowWidget: React.FC<InvestNowWidgetProps> = ({ className, content }) => {
+export const InvestNowWidget: React.FC<InvestNowWidgetProps> = ({ className, campaign }) => {
   const auth = useAuthContext();
   const router = useRouter();
   const routes = useRoutes();
@@ -32,11 +32,16 @@ export const InvestNowWidget: React.FC<InvestNowWidgetProps> = ({ className, con
 
   const handleOnInvestNowClick = () => {
     if (auth.hasActiveSession) {
-      getCheckoutURL({ checkout: { redirectURL: `${process.env.NEXT_PUBLIC_BASE_URL}${router.asPath}` } });
+      getCheckoutURL({
+        checkout: { redirectURL: `${process.env.NEXT_PUBLIC_BASE_URL}${router.asPath}` },
+        campaign,
+      });
     } else {
       router.push(`${routes.auth.signIn}?redirectTo=${process.env.NEXT_PUBLIC_BASE_URL}${router.asPath}`);
     }
   };
+
+  const content = campaign.content;
 
   return (
     <div className={clsx(styles["invest-now-widget"], className)}>

--- a/app/src/app/business/BusinessDetails/InvestNowWidget/InvestNowWidget.types.ts
+++ b/app/src/app/business/BusinessDetails/InvestNowWidget/InvestNowWidget.types.ts
@@ -1,8 +1,8 @@
-import { BusinessCampaignContent } from "api/codegen";
+import { BusinessCampaign } from "api/codegen";
 import { ReactNode } from "react";
 
 export type InvestNowWidgetProps = {
   children?: ReactNode;
   className?: string;
-  content: BusinessCampaignContent;
+  campaign: BusinessCampaign;
 };

--- a/app/src/context/auth/AuthContextController.tsx
+++ b/app/src/context/auth/AuthContextController.tsx
@@ -33,7 +33,7 @@ export const AuthContextController = ({ children }: AuthContextControllerProps) 
 
       if (event === "SIGNED_IN" && s?.user?.id) {
         try {
-          await fetch("/api/auth", {
+          await fetch(routes.api.auth, {
             method: "POST",
             headers: new Headers({ "Content-Type": "application/json" }),
             credentials: "same-origin",

--- a/app/src/context/checkout/CheckoutContext.types.ts
+++ b/app/src/context/checkout/CheckoutContext.types.ts
@@ -1,3 +1,4 @@
+import { BusinessCampaign } from "api/codegen";
 import { ReactNode } from "react";
 
 export type CheckoutContextControllerProps = {
@@ -9,6 +10,13 @@ export type BTCPayCheckoutOptions = {
   checkout: {
     redirectURL: string;
   };
+  campaign: BusinessCampaign;
+};
+
+export type BTCPayInvoiceMetadata = {
+  businessId: string;
+  campaignId: string;
+  buyerEmail: string;
 };
 
 export type CheckoutState =

--- a/app/src/context/checkout/CheckoutContextController.tsx
+++ b/app/src/context/checkout/CheckoutContextController.tsx
@@ -5,7 +5,13 @@ import { useToastContext } from "hooks/useToastContext/useToastContext";
 import { Typography } from "ui/typography/Typography";
 
 import { CheckoutContext } from "./CheckoutContext";
-import { BTCPayCheckoutOptions, CheckoutContextControllerProps, CheckoutState } from "./CheckoutContext.types";
+import {
+  BTCPayCheckoutOptions,
+  BTCPayInvoiceMetadata,
+  CheckoutContextControllerProps,
+  CheckoutState,
+} from "./CheckoutContext.types";
+import { useRoutes } from "hooks/useRoutes/useRoutes";
 
 export const CheckoutContextController = ({ children }: CheckoutContextControllerProps) => {
   const [checkoutState, setCheckoutState] = useState<CheckoutState>(undefined);
@@ -14,21 +20,21 @@ export const CheckoutContextController = ({ children }: CheckoutContextControlle
 
   const auth = useAuthContext();
   const toast = useToastContext();
+  const routes = useRoutes();
 
-  const getCheckoutURL = async ({ checkout }: BTCPayCheckoutOptions) => {
+  const getCheckoutURL = async ({ checkout, campaign }: BTCPayCheckoutOptions) => {
     try {
       setIsLoading(true);
 
-      // @TODO get businessId from business mcs
-      const businessId = "6e39hBHXvVwWvJUhSb2wKoBden7Ze4zrEDmq3F3f3Gex";
-      const buyerEmail = auth.session?.user?.email;
+      const buyerEmail = auth.session?.user?.email!;
 
-      // @TODO get store id from business mcs
-      const storeId = "6e39hBHXvVwWvJUhSb2wKoBden7Ze4zrEDmq3F3f3Gex";
+      const businessId = campaign.businessId;
+      const storeId = campaign.btcPayServerStoreId;
+      const campaignId = campaign.id;
 
-      const metadata = { businessId, buyerEmail };
+      const metadata: BTCPayInvoiceMetadata = { businessId, buyerEmail, campaignId };
 
-      const response = await fetch(`/api/getCheckoutURL`, {
+      const response = await fetch(routes.api.getCheckoutURL, {
         method: "POST",
         headers: {
           Accept: "application/json",

--- a/app/src/hooks/useRoutes/useRoutes.tsx
+++ b/app/src/hooks/useRoutes/useRoutes.tsx
@@ -9,6 +9,11 @@ type RouteMap = {
   auth: {
     signIn: string;
   };
+  api: {
+    getCheckoutURL: string;
+    auth: string;
+    graphql: string;
+  };
   invest: {
     grid: string;
     map: string;
@@ -17,7 +22,7 @@ type RouteMap = {
   home: string;
 };
 
-export const useRoutes: () => RouteMap = () => ({
+export const routes: RouteMap = {
   realEstate: {
     solana: {
       properties: "/real-estate/solana",
@@ -28,10 +33,17 @@ export const useRoutes: () => RouteMap = () => ({
   auth: {
     signIn: "/a/ingresa", // @TODO resolve i18n paths for all languages
   },
+  api: {
+    getCheckoutURL: `/api/getCheckoutURL`,
+    auth: `/api/auth`,
+    graphql: `/api/graphql`,
+  },
   invest: {
     grid: "/i",
     map: "/i/map", // @TODO resolve i18n paths for all languages
   },
   home: "/",
   campaign: (campaignSlug) => `/c/${campaignSlug}`,
-});
+};
+
+export const useRoutes: () => RouteMap = () => routes;

--- a/app/src/pages/api/getCheckoutURL.ts
+++ b/app/src/pages/api/getCheckoutURL.ts
@@ -1,10 +1,16 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
+import { BTCPayInvoiceMetadata } from "context/checkout/CheckoutContext.types";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const metadata = { businessId: req.body.metadata.businessId, buyerEmail: req.body.metadata.buyerEmail };
+    const metadata: BTCPayInvoiceMetadata = {
+      businessId: req.body.metadata.businessId,
+      buyerEmail: req.body.metadata.buyerEmail,
+      campaignId: req.body.metadata.campaignId,
+    };
+
     const { storeId, checkout } = req.body;
 
     const endpoint = `${process.env.BTC_PAY_SERVER_BASE_URL}/stores/${storeId}/invoices`;

--- a/app/src/pages/api/graphql.ts
+++ b/app/src/pages/api/graphql.ts
@@ -13,6 +13,7 @@ import getActiveBusinessCampaigns from "./business/resolvers/queries/getActiveBu
 import getBusinessesByUserId from "./business/resolvers/queries/getBusinessesByUserId";
 import getBusinessCampaignBySlug from "./business/resolvers/queries/getBusinessCampaignBySlug";
 import createBusiness from "./business/resolvers/mutations/createBusiness";
+import { routes } from "hooks/useRoutes/useRoutes";
 
 const schemas = loadTypedefsSync(path.join(process.cwd(), "/src/pages/api/business/schema.graphql"), {
   loaders: [new GraphQLFileLoader()],
@@ -58,7 +59,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   await startServer;
 
   await apolloServer.createHandler({
-    path: "/api/graphql",
+    path: routes.api.graphql,
   })(req, res);
 
   return null;

--- a/app/src/providers/graphql/client.ts
+++ b/app/src/providers/graphql/client.ts
@@ -1,6 +1,7 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
+import { routes } from "hooks/useRoutes/useRoutes";
 
 export const GQLClient = new ApolloClient({
-  uri: "/api/graphql",
+  uri: routes.api.graphql,
   cache: new InMemoryCache(),
 });


### PR DESCRIPTION
This PR updates `getCheckoutURL` to pass down dynamic `campaignId`, `storeId`  & `businessId` from the current campaign. 

Example:

For: `https://btc.bancosatoshi.com/api/v1/stores/6e39hBHXvVwWvJUhSb2wKoBden7Ze4zrEDmq3F3f3Gex/invoices/JDiDd6inanXxJxfz5EBc9J`

```
"metadata": {
        "businessId": "f33a770e-8584-4dcd-a1b3-e5ae42460e61",
        "buyerEmail": "gus@aufacicenta.com",
        "campaignId": "4ca6c20c-5d58-4468-b07f-b90ed2ec5884"
    },
```

We got this response ☝️ 

And the invoice is created: 

<img width="1440" alt="Screen Shot 2021-11-26 at 23 35 57" src="https://user-images.githubusercontent.com/4053518/143669479-7c9de665-db98-49f7-a57a-90f541049e9a.png">


NOTE: This PR updates the `useRoutes` hook too. 